### PR TITLE
[feat] #102 올인 모드(All-in Mode) 진입 로직 및 UI 구현 (Re-submission)

### DIFF
--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -11,13 +11,26 @@ class FocusManager: ObservableObject {
     @Published var timeRemaining: Int = 0
     @Published var isFocusing: Bool = false
     @Published var showSuccessScreen: Bool = false
+    @Published var isAllInModeActive: Bool = false {
+        didSet {
+            UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")
+        }
+    }
     
     private var timer: AnyCancellable?
     private let deviceActivityCenter = DeviceActivityCenter()
     private let store = ManagedSettingsStore()
     private let sharedDefaults = UserDefaults(suiteName: "group.com.unwind.data")
     
-    private init() {}
+    private init() {
+        self.isAllInModeActive = UserDefaults.standard.bool(forKey: "isAllInModeActive")
+        
+        // 만약 앱 실행 시 올인 모드가 활성 상태라면 차단 재설정
+        if isAllInModeActive {
+            activateShield()
+            startAllInMonitoring()
+        }
+    }
     
     func startFocus(on schedule: Schedule) {
         self.showSuccessScreen = false
@@ -48,8 +61,25 @@ class FocusManager: ObservableObject {
         timer?.cancel()
         timer = nil
         
+        // 올인 모드가 아닐 때만 차단을 해제합니다.
+        if !isAllInModeActive {
+            deactivateShield()
+            stopMonitoring()
+        }
+    }
+    
+    /// 올인 모드를 시작합니다.
+    func startAllInMode() {
+        isAllInModeActive = true
+        activateShield()
+        startAllInMonitoring()
+    }
+    
+    /// 올인 모드를 중단하거나 완료했을 때 호출됩니다.
+    func stopAllInMode() {
+        isAllInModeActive = false
         deactivateShield()
-        stopMonitoring()
+        stopAllInMonitoring()
     }
     
     private func tick() {
@@ -126,5 +156,23 @@ class FocusManager: ObservableObject {
     private func stopMonitoring() {
         deviceActivityCenter.stopMonitoring([DeviceActivityName("com.unwind.focusSession")])
     }
+    
+    private func startAllInMonitoring() {
+        let name = DeviceActivityName("com.unwind.allInMode")
+        let activitySchedule = DeviceActivitySchedule(
+            intervalStart: DateComponents(hour: 0, minute: 0),
+            intervalEnd: DateComponents(hour: 23, minute: 59),
+            repeats: true
+        )
+        
+        do {
+            try deviceActivityCenter.startMonitoring(name, during: activitySchedule)
+        } catch {
+            print("Failed to start All-in monitoring: \(error)")
+        }
+    }
+    
+    private func stopAllInMonitoring() {
+        deviceActivityCenter.stopMonitoring([DeviceActivityName("com.unwind.allInMode")])
+    }
 }
-

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -7,6 +7,15 @@ class HomeViewModel: ObservableObject {
     @Published var filteredSchedules: [Schedule] = []
     @Published var dateChips: [Date] = []
     
+    // 오늘 남은 스케줄이 있는지 확인
+    var hasIncompleteSchedulesToday: Bool {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        return repository.schedules.contains { 
+            calendar.isDate($0.createdAt, inSameDayAs: today) && !$0.isCompleted && $0.deletedAt == nil
+        }
+    }
+    
     private let repository: ScheduleRepository
     private var cancellables = Set<AnyCancellable>()
     

--- a/ios-app/Unwind/Unwind/Views/TimerView.swift
+++ b/ios-app/Unwind/Unwind/Views/TimerView.swift
@@ -57,6 +57,14 @@ struct TimerView: View {
                     dismiss()
                 }
         }
+        .alert("정말 포기하시겠습니까?", isPresented: $showingAbandonAlert) {
+            Button("계속 집중하기", role: .cancel) { }
+            Button("포기하기", role: .destructive) {
+                focusManager.abandonFocus()
+            }
+        } message: {
+            Text("이번 집중은 실패로 기록됩니다.")
+        }
     }
     
     private var progress: CGFloat {


### PR DESCRIPTION
## 개요
실수로 main에 머지되었던 102번 이슈의 변경 사항을 다시 develop 브랜치로 반영하기 위해 생성된 PR입니다.

## 주요 변경 사항
- FocusManager: 올인 모드 상태 관리 및 무제한 모니터링 로직
- HomeViewModel: 오늘 미완료 스케줄 존재 여부 확인 프로퍼티 추가
- ContentView: 올인 모드 토글 버튼 및 상태 배너 UI 추가
- TimerView/Schedule: 기존 기능과의 충돌 해결 및 통합

## 관련 이슈
- Refs #102