### PR TITLE
[feat] #103 올인 모드 진행률 관리 및 스케줄 완료 토글 구현

### DIFF
--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -95,36 +95,46 @@ struct ContentView: View {
     
     private var scheduleListView: some View {
         ForEach(homeViewModel.filteredSchedules) { schedule in
-            Button {
-                if !schedule.isCompleted && !focusManager.isAllInModeActive {
-                    focusManager.startFocus(on: schedule)
-                    showingTimer = true
+            HStack(spacing: 16) {
+                // 체크박스 (올인 모드에서 주요 인터랙션)
+                Button {
+                    homeViewModel.toggleCompletion(for: schedule)
+                } label: {
+                    Image(systemName: schedule.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundColor(schedule.isCompleted ? .green : .gray)
                 }
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(schedule.name)
-                            .font(.headline)
-                            .foregroundColor(schedule.isCompleted ? .secondary : .primary)
-                        Text("\(schedule.durationSeconds / 60)분 집중")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                
+                // 스케줄 정보 (상세 보기/타이머 시작)
+                Button {
+                    if !schedule.isCompleted && !focusManager.isAllInModeActive {
+                        focusManager.startFocus(on: schedule)
+                        showingTimer = true
                     }
-                    Spacer()
-                    if schedule.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                    } else if schedule.syncStatus == .pending {
-                        Image(systemName: "cloud.badge.plus")
-                            .foregroundColor(.orange)
-                            .font(.caption)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(schedule.name)
+                                .font(.headline)
+                                .foregroundColor(schedule.isCompleted ? .secondary : .primary)
+                            Text("\(schedule.durationSeconds / 60)분 집중")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if !schedule.isCompleted && schedule.syncStatus == .pending {
+                            Image(systemName: "cloud.badge.plus")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             .contextMenu {
                 if !schedule.isCompleted {
                     Button {
@@ -151,9 +161,18 @@ struct ContentView: View {
 
     private var allInModeBanner: some View {
         HStack {
-            Image(systemName: "flame.fill")
-            Text("올인 모드 진행 중")
-                .fontWeight(.bold)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "flame.fill")
+                    Text("올인 모드 진행 중")
+                        .fontWeight(.bold)
+                }
+                if !homeViewModel.todayProgressText.isEmpty {
+                    Text(homeViewModel.todayProgressText)
+                        .font(.caption)
+                        .opacity(0.9)
+                }
+            }
             Spacer()
             Button("중단") {
                 focusManager.stopAllInMode()


### PR DESCRIPTION
## 개요
올인 모드 중 사용자가 스케줄을 하나씩 클리어하며 진행률을 확인할 수 있는 기능을 구현했습니다.

## 주요 변경 사항
1. **스케줄 완료 토글 로직 (HomeViewModel.swift)**
   - `toggleCompletion(for:)` 메서드를 구현하여 리스트에서 즉시 완료/미완료 상태를 전환할 수 있게 했습니다.
   - 완료 시 `status = .completed`, 미완료 시 `status = .pending`으로 상태를 관리합니다.

2. **진행률 계산 및 표시 (HomeViewModel.swift & ContentView.swift)**
   - 오늘 예정된 전체 스케줄 대비 완료된 스케줄의 비율을 "n/m 완료" 형태로 계산하는 `todayProgressText`를 추가했습니다.
   - 올인 모드 활성화 시 표시되는 상단 배너에 이 진행률 텍스트를 연동했습니다.

3. **리스트 UI 업데이트 (ContentView.swift)**
   - 스케줄 리스트 아이템 좌측에 체크박스 버튼을 추가하여 직관적인 완료 인터랙션을 제공합니다.
   - 체크 여부에 따라 아이콘과 색상이 실시간으로 변경됩니다.

## 관련 이슈

- Closes #103
