### PR TITLE
[feat] #104 올인 모드 전용 Shield UI 및 진행률 표시 구현

### DIFF
--- a/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
+++ b/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
@@ -25,33 +25,48 @@ class ShieldConfigurationProvider: ShieldConfigurationDataSource {
     }
     
     private func createCustomConfiguration() -> ShieldConfiguration {
-        // 현재 활성화된 스케줄 이름과 남은 시간을 가져옵니다.
-        let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
-        let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+        // 올인 모드 여부를 확인합니다.
+        let isAllInMode = sharedDefaults?.bool(forKey: "isAllInModeActive") ?? false
         
-        // 남은 시간을 HH:MM:SS 형식으로 변환합니다.
-        let hours = remainingSeconds / 3600
-        let minutes = (remainingSeconds % 3600) / 60
-        let seconds = remainingSeconds % 60
-        let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        let titleText: String
+        let subtitleText: String
+        
+        if isAllInMode {
+            // 올인 모드일 경우의 문구
+            let progress = sharedDefaults?.string(forKey: "allInModeProgress") ?? ""
+            titleText = "올인 모드 진행 중!"
+            subtitleText = "오늘의 모든 스케줄을 완료할 때까지 앱이 차단됩니다.\n현재 진행 상황: \(progress)"
+        } else {
+            // 일반 스케줄 모드일 경우의 문구
+            let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
+            let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+            
+            let hours = remainingSeconds / 3600
+            let minutes = (remainingSeconds % 3600) / 60
+            let seconds = remainingSeconds % 60
+            let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            
+            titleText = "지금은 '\(scheduleName)' 중!"
+            subtitleText = "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요."
+        }
         
         return ShieldConfiguration(
             backgroundBlurStyle: .dark,
             backgroundColor: .systemBackground,
-            icon: UIImage(systemName: "clock.badge.checkmark"),
+            icon: UIImage(systemName: isAllInMode ? "bolt.fill" : "clock.badge.checkmark"),
             title: ShieldConfiguration.Label(
-                text: "지금은 '\(scheduleName)' 중!",
+                text: titleText,
                 color: .label
             ),
             subtitle: ShieldConfiguration.Label(
-                text: "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요.",
+                text: subtitleText,
                 color: .secondaryLabel
             ),
             primaryButtonLabel: ShieldConfiguration.Label(
                 text: "확인",
                 color: .white
             ),
-            primaryButtonBackgroundColor: .systemBlue
+            primaryButtonBackgroundColor: isAllInMode ? .systemOrange : .systemBlue
         )
     }
 }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -95,36 +95,46 @@ struct ContentView: View {
     
     private var scheduleListView: some View {
         ForEach(homeViewModel.filteredSchedules) { schedule in
-            Button {
-                if !schedule.isCompleted && !focusManager.isAllInModeActive {
-                    focusManager.startFocus(on: schedule)
-                    showingTimer = true
+            HStack(spacing: 16) {
+                // 체크박스 (올인 모드에서 주요 인터랙션)
+                Button {
+                    homeViewModel.toggleCompletion(for: schedule)
+                } label: {
+                    Image(systemName: schedule.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundColor(schedule.isCompleted ? .green : .gray)
                 }
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(schedule.name)
-                            .font(.headline)
-                            .foregroundColor(schedule.isCompleted ? .secondary : .primary)
-                        Text("\(schedule.durationSeconds / 60)분 집중")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                
+                // 스케줄 정보 (상세 보기/타이머 시작)
+                Button {
+                    if !schedule.isCompleted && !focusManager.isAllInModeActive {
+                        focusManager.startFocus(on: schedule)
+                        showingTimer = true
                     }
-                    Spacer()
-                    if schedule.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                    } else if schedule.syncStatus == .pending {
-                        Image(systemName: "cloud.badge.plus")
-                            .foregroundColor(.orange)
-                            .font(.caption)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(schedule.name)
+                                .font(.headline)
+                                .foregroundColor(schedule.isCompleted ? .secondary : .primary)
+                            Text("\(schedule.durationSeconds / 60)분 집중")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if !schedule.isCompleted && schedule.syncStatus == .pending {
+                            Image(systemName: "cloud.badge.plus")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             .contextMenu {
                 if !schedule.isCompleted {
                     Button {
@@ -151,9 +161,18 @@ struct ContentView: View {
 
     private var allInModeBanner: some View {
         HStack {
-            Image(systemName: "flame.fill")
-            Text("올인 모드 진행 중")
-                .fontWeight(.bold)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "flame.fill")
+                    Text("올인 모드 진행 중")
+                        .fontWeight(.bold)
+                }
+                if !homeViewModel.todayProgressText.isEmpty {
+                    Text(homeViewModel.todayProgressText)
+                        .font(.caption)
+                        .opacity(0.9)
+                }
+            }
             Spacer()
             Button("중단") {
                 focusManager.stopAllInMode()

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -14,6 +14,7 @@ class FocusManager: ObservableObject {
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")
+            sharedDefaults?.set(isAllInModeActive, forKey: "isAllInModeActive")
         }
     }
     

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -6,7 +6,11 @@ class HomeViewModel: ObservableObject {
     @Published var selectedDate: Date = Date()
     @Published var filteredSchedules: [Schedule] = []
     @Published var dateChips: [Date] = []
-    @Published var todayProgressText: String = ""
+    @Published var todayProgressText: String = "" {
+        didSet {
+            UserDefaults(suiteName: "group.com.unwind.data")?.set(todayProgressText, forKey: "allInModeProgress")
+        }
+    }
     
     // 오늘 남은 스케줄이 있는지 확인
     var hasIncompleteSchedulesToday: Bool {


### PR DESCRIPTION
## 개요
올인 모드(All-in Mode) 실행 중 차단된 앱에 접근했을 때, 현재 진행 중인 모드가 올인 모드임을 알리고 진행률을 확인할 수 있는 전용 Shield UI를 구현했습니다.

## 주요 변경 사항
1. **데이터 공유 설정 (App Group)**
   - Main App과 Shield Extension 간의 데이터 공유를 위해 App Group(`group.com.unwind.data`) 기반의 `UserDefaults` 동기화 로직을 강화했습니다.
   - `isAllInModeActive` 상태 및 `allInModeProgress` 진행률 텍스트를 실시간으로 공유합니다.

2. **Shield UI 분기 처리 (ShieldConfigurationExtension)**
   - `ShieldConfigurationProvider`에서 올인 모드 활성화 여부를 감지합니다.
   - **일반 모드**: 기존처럼 스케줄 이름과 남은 시간을 표시합니다.
   - **올인 모드**: "올인 모드 진행 중!" 타이틀과 함께 "n/m 완료" 진행 상황을 서브타이틀로 표시합니다.
   - 올인 모드 전용 아이콘(`bolt.fill`) 및 주황색 버튼 테마를 적용했습니다.

3. **로직 보완**
   - `FocusManager`에서 올인 모드 토글 시 공유 `UserDefaults`를 즉시 업데이트합니다.
   - `HomeViewModel`에서 스케줄 완료 상태 변경 시 진행률 텍스트를 공유 `UserDefaults`에 동기화합니다.

## 관련 이슈
- Closes #104
- 관련 선행 작업: #103 (진행률 관리 로직)
