### PR TITLE
[feat] #105 모든 스케줄 완료 시 올인 모드 자동 해제 로직 구현

### DIFF
--- a/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
+++ b/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
@@ -25,33 +25,48 @@ class ShieldConfigurationProvider: ShieldConfigurationDataSource {
     }
     
     private func createCustomConfiguration() -> ShieldConfiguration {
-        // 현재 활성화된 스케줄 이름과 남은 시간을 가져옵니다.
-        let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
-        let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+        // 올인 모드 여부를 확인합니다.
+        let isAllInMode = sharedDefaults?.bool(forKey: "isAllInModeActive") ?? false
         
-        // 남은 시간을 HH:MM:SS 형식으로 변환합니다.
-        let hours = remainingSeconds / 3600
-        let minutes = (remainingSeconds % 3600) / 60
-        let seconds = remainingSeconds % 60
-        let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        let titleText: String
+        let subtitleText: String
+        
+        if isAllInMode {
+            // 올인 모드일 경우의 문구
+            let progress = sharedDefaults?.string(forKey: "allInModeProgress") ?? ""
+            titleText = "올인 모드 진행 중!"
+            subtitleText = "오늘의 모든 스케줄을 완료할 때까지 앱이 차단됩니다.\n현재 진행 상황: \(progress)"
+        } else {
+            // 일반 스케줄 모드일 경우의 문구
+            let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
+            let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+            
+            let hours = remainingSeconds / 3600
+            let minutes = (remainingSeconds % 3600) / 60
+            let seconds = remainingSeconds % 60
+            let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            
+            titleText = "지금은 '\(scheduleName)' 중!"
+            subtitleText = "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요."
+        }
         
         return ShieldConfiguration(
             backgroundBlurStyle: .dark,
             backgroundColor: .systemBackground,
-            icon: UIImage(systemName: "clock.badge.checkmark"),
+            icon: UIImage(systemName: isAllInMode ? "bolt.fill" : "clock.badge.checkmark"),
             title: ShieldConfiguration.Label(
-                text: "지금은 '\(scheduleName)' 중!",
+                text: titleText,
                 color: .label
             ),
             subtitle: ShieldConfiguration.Label(
-                text: "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요.",
+                text: subtitleText,
                 color: .secondaryLabel
             ),
             primaryButtonLabel: ShieldConfiguration.Label(
                 text: "확인",
                 color: .white
             ),
-            primaryButtonBackgroundColor: .systemBlue
+            primaryButtonBackgroundColor: isAllInMode ? .systemOrange : .systemBlue
         )
     }
 }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -95,36 +95,46 @@ struct ContentView: View {
     
     private var scheduleListView: some View {
         ForEach(homeViewModel.filteredSchedules) { schedule in
-            Button {
-                if !schedule.isCompleted && !focusManager.isAllInModeActive {
-                    focusManager.startFocus(on: schedule)
-                    showingTimer = true
+            HStack(spacing: 16) {
+                // 체크박스 (올인 모드에서 주요 인터랙션)
+                Button {
+                    homeViewModel.toggleCompletion(for: schedule)
+                } label: {
+                    Image(systemName: schedule.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundColor(schedule.isCompleted ? .green : .gray)
                 }
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(schedule.name)
-                            .font(.headline)
-                            .foregroundColor(schedule.isCompleted ? .secondary : .primary)
-                        Text("\(schedule.durationSeconds / 60)분 집중")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                
+                // 스케줄 정보 (상세 보기/타이머 시작)
+                Button {
+                    if !schedule.isCompleted && !focusManager.isAllInModeActive {
+                        focusManager.startFocus(on: schedule)
+                        showingTimer = true
                     }
-                    Spacer()
-                    if schedule.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                    } else if schedule.syncStatus == .pending {
-                        Image(systemName: "cloud.badge.plus")
-                            .foregroundColor(.orange)
-                            .font(.caption)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(schedule.name)
+                                .font(.headline)
+                                .foregroundColor(schedule.isCompleted ? .secondary : .primary)
+                            Text("\(schedule.durationSeconds / 60)분 집중")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if !schedule.isCompleted && schedule.syncStatus == .pending {
+                            Image(systemName: "cloud.badge.plus")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             .contextMenu {
                 if !schedule.isCompleted {
                     Button {
@@ -151,9 +161,18 @@ struct ContentView: View {
 
     private var allInModeBanner: some View {
         HStack {
-            Image(systemName: "flame.fill")
-            Text("올인 모드 진행 중")
-                .fontWeight(.bold)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "flame.fill")
+                    Text("올인 모드 진행 중")
+                        .fontWeight(.bold)
+                }
+                if !homeViewModel.todayProgressText.isEmpty {
+                    Text(homeViewModel.todayProgressText)
+                        .font(.caption)
+                        .opacity(0.9)
+                }
+            }
             Spacer()
             Button("중단") {
                 focusManager.stopAllInMode()

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -59,6 +59,13 @@ struct ContentView: View {
             } message: {
                 Text("오늘 예정된 미완료 스케줄이 없습니다.")
             }
+            .alert("올인 모드 완료!", isPresented: $focusManager.showAllInCompletePopup) {
+                Button("축하합니다!") {
+                    focusManager.showAllInCompletePopup = false
+                }
+            } message: {
+                Text("오늘의 모든 스케줄을 완료하셨습니다.\n정말 고생 많으셨어요! 🎉")
+            }
             .alert("스케줄 삭제", isPresented: Binding(
                 get: { scheduleToDelete != nil },
                 set: { if !$0 { scheduleToDelete = nil } }

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -14,6 +14,7 @@ class FocusManager: ObservableObject {
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")
+            sharedDefaults?.set(isAllInModeActive, forKey: "isAllInModeActive")
         }
     }
     

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -11,6 +11,7 @@ class FocusManager: ObservableObject {
     @Published var timeRemaining: Int = 0
     @Published var isFocusing: Bool = false
     @Published var showSuccessScreen: Bool = false
+    @Published var showAllInCompletePopup: Bool = false
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -89,5 +89,23 @@ class HomeViewModel: ObservableObject {
         }
         updatedSchedule.updatedAt = Date()
         repository.updateSchedule(updatedSchedule)
+        
+        // 전체 완료 여부 체크 (올인 모드 해제 로직)
+        checkAllInCompletion()
+    }
+    
+    private func checkAllInCompletion() {
+        guard FocusManager.shared.isAllInModeActive else { return }
+        
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let todaysSchedules = repository.schedules.filter { 
+            calendar.isDate($0.createdAt, inSameDayAs: today) && $0.deletedAt == nil
+        }
+        
+        if !todaysSchedules.isEmpty && todaysSchedules.allSatisfy({ $0.isCompleted }) {
+            FocusManager.shared.stopAllInMode()
+            FocusManager.shared.showAllInCompletePopup = true
+        }
     }
 }

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -6,7 +6,11 @@ class HomeViewModel: ObservableObject {
     @Published var selectedDate: Date = Date()
     @Published var filteredSchedules: [Schedule] = []
     @Published var dateChips: [Date] = []
-    @Published var todayProgressText: String = ""
+    @Published var todayProgressText: String = "" {
+        didSet {
+            UserDefaults(suiteName: "group.com.unwind.data")?.set(todayProgressText, forKey: "allInModeProgress")
+        }
+    }
     
     // 오늘 남은 스케줄이 있는지 확인
     var hasIncompleteSchedulesToday: Bool {


### PR DESCRIPTION
## 개요
올인 모드(All-in Mode) 중 오늘의 모든 스케줄을 완료했을 때, 자동으로 차단을 해제하고 사용자에게 축하 메시지를 표시하는 기능을 구현했습니다.

## 주요 변경 사항
1. **자동 해제 로직 (HomeViewModel.swift)**
   - `toggleCompletion(for:)` 메서드 내부에서 스케줄을 완료 처리한 후, 오늘의 모든 스케줄이 완료되었는지 확인하는 `checkAllInCompletion()` 로직을 추가했습니다.
   - 모든 스케줄이 완료되면 `FocusManager.shared.stopAllInMode()`를 호출하여 차단을 즉시 해제합니다.

2. **성공 상태 트리거 (FocusManager.swift)**
   - UI에 축하 팝업을 띄우기 위한 `@Published var showAllInCompletePopup` 상태 변수를 추가했습니다.

3. **축하 UI 연동 (ContentView.swift)**
   - `showAllInCompletePopup` 상태를 감시하여, 모든 목표 달성 시 "올인 모드 완료!" Alert를 화면에 표시하도록 구현했습니다.

## 관련 이슈
- Closes #105
- 관련 선행 작업: #103 (진행률 관리), #104 (Shield UI)
