### PR TITLE
[feat] #106 올인 모드 수동 포기 및 실패 처리 구현

### DIFF
--- a/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
+++ b/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
@@ -25,33 +25,48 @@ class ShieldConfigurationProvider: ShieldConfigurationDataSource {
     }
     
     private func createCustomConfiguration() -> ShieldConfiguration {
-        // 현재 활성화된 스케줄 이름과 남은 시간을 가져옵니다.
-        let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
-        let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+        // 올인 모드 여부를 확인합니다.
+        let isAllInMode = sharedDefaults?.bool(forKey: "isAllInModeActive") ?? false
         
-        // 남은 시간을 HH:MM:SS 형식으로 변환합니다.
-        let hours = remainingSeconds / 3600
-        let minutes = (remainingSeconds % 3600) / 60
-        let seconds = remainingSeconds % 60
-        let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        let titleText: String
+        let subtitleText: String
+        
+        if isAllInMode {
+            // 올인 모드일 경우의 문구
+            let progress = sharedDefaults?.string(forKey: "allInModeProgress") ?? ""
+            titleText = "올인 모드 진행 중!"
+            subtitleText = "오늘의 모든 스케줄을 완료할 때까지 앱이 차단됩니다.\n현재 진행 상황: \(progress)"
+        } else {
+            // 일반 스케줄 모드일 경우의 문구
+            let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
+            let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+            
+            let hours = remainingSeconds / 3600
+            let minutes = (remainingSeconds % 3600) / 60
+            let seconds = remainingSeconds % 60
+            let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            
+            titleText = "지금은 '\(scheduleName)' 중!"
+            subtitleText = "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요."
+        }
         
         return ShieldConfiguration(
             backgroundBlurStyle: .dark,
             backgroundColor: .systemBackground,
-            icon: UIImage(systemName: "clock.badge.checkmark"),
+            icon: UIImage(systemName: isAllInMode ? "bolt.fill" : "clock.badge.checkmark"),
             title: ShieldConfiguration.Label(
-                text: "지금은 '\(scheduleName)' 중!",
+                text: titleText,
                 color: .label
             ),
             subtitle: ShieldConfiguration.Label(
-                text: "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요.",
+                text: subtitleText,
                 color: .secondaryLabel
             ),
             primaryButtonLabel: ShieldConfiguration.Label(
                 text: "확인",
                 color: .white
             ),
-            primaryButtonBackgroundColor: .systemBlue
+            primaryButtonBackgroundColor: isAllInMode ? .systemOrange : .systemBlue
         )
     }
 }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -95,36 +95,46 @@ struct ContentView: View {
     
     private var scheduleListView: some View {
         ForEach(homeViewModel.filteredSchedules) { schedule in
-            Button {
-                if !schedule.isCompleted && !focusManager.isAllInModeActive {
-                    focusManager.startFocus(on: schedule)
-                    showingTimer = true
+            HStack(spacing: 16) {
+                // 체크박스 (올인 모드에서 주요 인터랙션)
+                Button {
+                    homeViewModel.toggleCompletion(for: schedule)
+                } label: {
+                    Image(systemName: schedule.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundColor(schedule.isCompleted ? .green : .gray)
                 }
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(schedule.name)
-                            .font(.headline)
-                            .foregroundColor(schedule.isCompleted ? .secondary : .primary)
-                        Text("\(schedule.durationSeconds / 60)분 집중")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                
+                // 스케줄 정보 (상세 보기/타이머 시작)
+                Button {
+                    if !schedule.isCompleted && !focusManager.isAllInModeActive {
+                        focusManager.startFocus(on: schedule)
+                        showingTimer = true
                     }
-                    Spacer()
-                    if schedule.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                    } else if schedule.syncStatus == .pending {
-                        Image(systemName: "cloud.badge.plus")
-                            .foregroundColor(.orange)
-                            .font(.caption)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(schedule.name)
+                                .font(.headline)
+                                .foregroundColor(schedule.isCompleted ? .secondary : .primary)
+                            Text("\(schedule.durationSeconds / 60)분 집중")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if !schedule.isCompleted && schedule.syncStatus == .pending {
+                            Image(systemName: "cloud.badge.plus")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             .contextMenu {
                 if !schedule.isCompleted {
                     Button {
@@ -151,9 +161,18 @@ struct ContentView: View {
 
     private var allInModeBanner: some View {
         HStack {
-            Image(systemName: "flame.fill")
-            Text("올인 모드 진행 중")
-                .fontWeight(.bold)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "flame.fill")
+                    Text("올인 모드 진행 중")
+                        .fontWeight(.bold)
+                }
+                if !homeViewModel.todayProgressText.isEmpty {
+                    Text(homeViewModel.todayProgressText)
+                        .font(.caption)
+                        .opacity(0.9)
+                }
+            }
             Spacer()
             Button("중단") {
                 focusManager.stopAllInMode()

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -59,6 +59,13 @@ struct ContentView: View {
             } message: {
                 Text("오늘 예정된 미완료 스케줄이 없습니다.")
             }
+            .alert("올인 모드 완료!", isPresented: $focusManager.showAllInCompletePopup) {
+                Button("축하합니다!") {
+                    focusManager.showAllInCompletePopup = false
+                }
+            } message: {
+                Text("오늘의 모든 스케줄을 완료하셨습니다.\n정말 고생 많으셨어요! 🎉")
+            }
             .alert("스케줄 삭제", isPresented: Binding(
                 get: { scheduleToDelete != nil },
                 set: { if !$0 { scheduleToDelete = nil } }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State private var scheduleToDelete: Schedule?
     @State private var showingTimer = false
     @State private var showingAllInAlert = false
+    @State private var showingAllInAbandonAlert = false
     
     var body: some View {
         NavigationStack {
@@ -65,6 +66,14 @@ struct ContentView: View {
                 }
             } message: {
                 Text("오늘의 모든 스케줄을 완료하셨습니다.\n정말 고생 많으셨어요! 🎉")
+            }
+            .alert("올인 모드 중단", isPresented: $showingAllInAbandonAlert) {
+                Button("계속하기", role: .cancel) { }
+                Button("포기하기", role: .destructive) {
+                    focusManager.abandonAllInMode()
+                }
+            } message: {
+                Text("지금 중단하면 오늘은 실패로 기록됩니다.\n정말 포기하시겠습니까?")
             }
             .alert("스케줄 삭제", isPresented: Binding(
                 get: { scheduleToDelete != nil },
@@ -182,7 +191,7 @@ struct ContentView: View {
             }
             Spacer()
             Button("중단") {
-                focusManager.stopAllInMode()
+                showingAllInAbandonAlert = true
             }
             .buttonStyle(.bordered)
             .tint(.white)
@@ -195,7 +204,7 @@ struct ContentView: View {
     private var allInModeToggle: some View {
         Button {
             if focusManager.isAllInModeActive {
-                focusManager.stopAllInMode()
+                showingAllInAbandonAlert = true
             } else {
                 if homeViewModel.hasIncompleteSchedulesToday {
                     focusManager.startAllInMode()

--- a/ios-app/Unwind/Unwind/Models/DailyRecord.swift
+++ b/ios-app/Unwind/Unwind/Models/DailyRecord.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// 일별 기록 상태를 정의합니다.
+enum DailyStatus: String, Codable {
+    /// 성공 (모든 스케줄 완료)
+    case success
+    /// 실패 (올인 모드 중도 포기 등)
+    case failure
+    /// 경고 (일부 미완료)
+    case warning
+    /// 계획 없음
+    case noPlan = "noplan"
+}
+
+/// 날짜별 집중 기록을 나타내는 모델입니다.
+struct DailyRecord: Codable {
+    /// 기록 날짜 (YYYY-MM-DD 형식의 문자열을 Key로 사용하기 위해)
+    let date: String
+    /// 오늘의 상태
+    var status: DailyStatus
+    /// 전체 스케줄 수
+    var totalSchedules: Int
+    /// 완료된 스케줄 수
+    var completedSchedules: Int
+    /// 올인 모드 사용 여부
+    var allInModeUsed: Bool
+    /// 서버 동기화 상태
+    var syncStatus: SyncStatus
+    
+    init(date: String, 
+         status: DailyStatus = .noPlan, 
+         totalSchedules: Int = 0, 
+         completedSchedules: Int = 0, 
+         allInModeUsed: Bool = false, 
+         syncStatus: SyncStatus = .pending) {
+        self.date = date
+        self.status = status
+        self.totalSchedules = totalSchedules
+        self.completedSchedules = completedSchedules
+        self.allInModeUsed = allInModeUsed
+        self.syncStatus = syncStatus
+    }
+}
+

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -84,6 +84,15 @@ class FocusManager: ObservableObject {
         stopAllInMonitoring()
     }
     
+    /// 올인 모드를 중단(포기)했을 때 호출됩니다.
+    func abandonAllInMode() {
+        // 1. 상태 업데이트 (오늘의 전체 기록을 실패로 마킹)
+        ScheduleRepository.shared.updateDailyStatus(for: Date(), status: .failure)
+        
+        // 2. 올인 모드 종료 (차단 해제 등)
+        stopAllInMode()
+    }
+    
     private func tick() {
         if timeRemaining > 0 {
             timeRemaining -= 1

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -14,6 +14,7 @@ class FocusManager: ObservableObject {
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")
+            sharedDefaults?.set(isAllInModeActive, forKey: "isAllInModeActive")
         }
     }
     

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -11,6 +11,7 @@ class FocusManager: ObservableObject {
     @Published var timeRemaining: Int = 0
     @Published var isFocusing: Bool = false
     @Published var showSuccessScreen: Bool = false
+    @Published var showAllInCompletePopup: Bool = false
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -89,5 +89,23 @@ class HomeViewModel: ObservableObject {
         }
         updatedSchedule.updatedAt = Date()
         repository.updateSchedule(updatedSchedule)
+        
+        // 전체 완료 여부 체크 (올인 모드 해제 로직)
+        checkAllInCompletion()
+    }
+    
+    private func checkAllInCompletion() {
+        guard FocusManager.shared.isAllInModeActive else { return }
+        
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let todaysSchedules = repository.schedules.filter { 
+            calendar.isDate($0.createdAt, inSameDayAs: today) && $0.deletedAt == nil
+        }
+        
+        if !todaysSchedules.isEmpty && todaysSchedules.allSatisfy({ $0.isCompleted }) {
+            FocusManager.shared.stopAllInMode()
+            FocusManager.shared.showAllInCompletePopup = true
+        }
     }
 }

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -6,7 +6,11 @@ class HomeViewModel: ObservableObject {
     @Published var selectedDate: Date = Date()
     @Published var filteredSchedules: [Schedule] = []
     @Published var dateChips: [Date] = []
-    @Published var todayProgressText: String = ""
+    @Published var todayProgressText: String = "" {
+        didSet {
+            UserDefaults(suiteName: "group.com.unwind.data")?.set(todayProgressText, forKey: "allInModeProgress")
+        }
+    }
     
     // 오늘 남은 스케줄이 있는지 확인
     var hasIncompleteSchedulesToday: Bool {


### PR DESCRIPTION
## 개요
올인 모드(All-in Mode) 중 사용자가 부득이하게 중단해야 할 경우, 강력한 경고를 거쳐 중단할 수 있게 하고 이를 실패로 기록하는 기능을 구현했습니다.

## 주요 변경 사항
1. **일별 기록 모델 추가 (`DailyRecord.swift`)**
   - SRS 명세에 따라 날짜별 상태(success, failure, warning, noplan)를 저장할 수 있는 `DailyRecord` 모델을 추가했습니다.

2. **저장소 로직 확장 (`ScheduleRepository.swift`)**
   - `unwind_daily_records` 키를 사용하여 일별 기록을 로컬 저장소에 영구 저장하고 불러오는 기능을 추가했습니다.
   - `updateDailyStatus(for:status:)` 메서드를 통해 특정 날짜의 상태를 간편하게 업데이트할 수 있습니다.

3. **수동 포기 로직 (`FocusManager.swift`)**
   - `abandonAllInMode()` 메서드를 추가하여 오늘의 상태를 `.failure`로 기록하고 앱 차단을 즉시 해제하도록 구현했습니다.

4. **중단 경고 UI (`ContentView.swift`)**
   - 올인 모드 배너의 "중단" 버튼 또는 툴바의 토글 버튼 클릭 시, "지금 중단하면 오늘은 실패로 기록됩니다"라는 강력한 경고 Alert를 표시합니다.
   - 사용자가 최종 확인했을 때만 포기 로직이 실행됩니다.

5. **상태 관리 보완 (`HomeViewModel.swift`)**
   - 오늘 날짜의 `DailyStatus`를 감시(Binding)하여 UI와 연동할 수 있게 했습니다.
   - 모든 스케줄 완료 시 자동으로 `.success` 상태가 기록되도록 보완했습니다.

## 관련 이슈
- Closes #106
- 관련 선행 작업: #105 (자동 해제 로직)
