### PR TITLE
[feat] #108 앱 버전 정보 표시 구현

### DIFF
--- a/ios-app/Unwind/Unwind/Utils/AppInfoUtil.swift
+++ b/ios-app/Unwind/Unwind/Utils/AppInfoUtil.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 앱의 버전 및 빌드 정보를 제공하는 유틸리티 클래스입니다.
+struct AppInfoUtil {
+    /// 앱의 버전 정보를 가져옵니다 (예: 1.0.0).
+    static var appVersion: String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+    
+    /// 앱의 빌드 번호를 가져옵니다 (예: 1).
+    static var buildNumber: String {
+        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+    
+    /// 표시용 전체 버전 문자열을 가져옵니다 (예: v1.0.0 (Build 1)).
+    static var fullVersionString: String {
+        return "v\(appVersion) (Build \(buildNumber))"
+    }
+}
+

--- a/ios-app/Unwind/Unwind/Views/MainTabView.swift
+++ b/ios-app/Unwind/Unwind/Views/MainTabView.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
                     HStack {
                         Text("버전")
                         Spacer()
-                        Text("v1.0.0")
+                        Text(AppInfoUtil.fullVersionString)
                             .foregroundColor(.secondary)
                     }
                 }


### PR DESCRIPTION
## 개요
사용자가 현재 설치된 앱의 버전과 빌드 정보를 확인할 수 있도록 설정 화면 하단에 버전 정보를 표시하는 기능을 구현했습니다.

## 주요 변경 사항
1. **앱 정보 유틸리티 추가 (`AppInfoUtil.swift`)**
   - `Bundle.main.infoDictionary`에서 `CFBundleShortVersionString`(버전)과 `CFBundleVersion`(빌드 번호)을 안전하게 읽어오는 유틸리티를 구현했습니다.
   - `fullVersionString` 프로퍼티를 통해 `v1.0.0 (Build 1)` 형식의 문자열을 제공합니다.

2. **설정 화면 UI 업데이트 (`MainTabView.swift`)**
   - 기존에 하드코딩되어 있던 "v1.0.0" 텍스트를 `AppInfoUtil`을 사용하여 동적으로 표시하도록 수정했습니다.

## 관련 이슈
- Closes #108
