### PR TITLE
[feat] #114 권한 거부 대응 안내 UI 및 로직 구현

### DIFF
--- a/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
+++ b/ios-app/Unwind/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
@@ -25,33 +25,48 @@ class ShieldConfigurationProvider: ShieldConfigurationDataSource {
     }
     
     private func createCustomConfiguration() -> ShieldConfiguration {
-        // 현재 활성화된 스케줄 이름과 남은 시간을 가져옵니다.
-        let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
-        let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+        // 올인 모드 여부를 확인합니다.
+        let isAllInMode = sharedDefaults?.bool(forKey: "isAllInModeActive") ?? false
         
-        // 남은 시간을 HH:MM:SS 형식으로 변환합니다.
-        let hours = remainingSeconds / 3600
-        let minutes = (remainingSeconds % 3600) / 60
-        let seconds = remainingSeconds % 60
-        let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        let titleText: String
+        let subtitleText: String
+        
+        if isAllInMode {
+            // 올인 모드일 경우의 문구
+            let progress = sharedDefaults?.string(forKey: "allInModeProgress") ?? ""
+            titleText = "올인 모드 진행 중!"
+            subtitleText = "오늘의 모든 스케줄을 완료할 때까지 앱이 차단됩니다.\n현재 진행 상황: \(progress)"
+        } else {
+            // 일반 스케줄 모드일 경우의 문구
+            let scheduleName = sharedDefaults?.string(forKey: "activeScheduleName") ?? "집중"
+            let remainingSeconds = sharedDefaults?.integer(forKey: "remainingSeconds") ?? 0
+            
+            let hours = remainingSeconds / 3600
+            let minutes = (remainingSeconds % 3600) / 60
+            let seconds = remainingSeconds % 60
+            let timeString = String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            
+            titleText = "지금은 '\(scheduleName)' 중!"
+            subtitleText = "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요."
+        }
         
         return ShieldConfiguration(
             backgroundBlurStyle: .dark,
             backgroundColor: .systemBackground,
-            icon: UIImage(systemName: "clock.badge.checkmark"),
+            icon: UIImage(systemName: isAllInMode ? "bolt.fill" : "clock.badge.checkmark"),
             title: ShieldConfiguration.Label(
-                text: "지금은 '\(scheduleName)' 중!",
+                text: titleText,
                 color: .label
             ),
             subtitle: ShieldConfiguration.Label(
-                text: "남은 시간: \(timeString)\n목표를 달성할 때까지 조금만 더 힘내세요.",
+                text: subtitleText,
                 color: .secondaryLabel
             ),
             primaryButtonLabel: ShieldConfiguration.Label(
                 text: "확인",
                 color: .white
             ),
-            primaryButtonBackgroundColor: .systemBlue
+            primaryButtonBackgroundColor: isAllInMode ? .systemOrange : .systemBlue
         )
     }
 }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -95,36 +95,46 @@ struct ContentView: View {
     
     private var scheduleListView: some View {
         ForEach(homeViewModel.filteredSchedules) { schedule in
-            Button {
-                if !schedule.isCompleted && !focusManager.isAllInModeActive {
-                    focusManager.startFocus(on: schedule)
-                    showingTimer = true
+            HStack(spacing: 16) {
+                // 체크박스 (올인 모드에서 주요 인터랙션)
+                Button {
+                    homeViewModel.toggleCompletion(for: schedule)
+                } label: {
+                    Image(systemName: schedule.isCompleted ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundColor(schedule.isCompleted ? .green : .gray)
                 }
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(schedule.name)
-                            .font(.headline)
-                            .foregroundColor(schedule.isCompleted ? .secondary : .primary)
-                        Text("\(schedule.durationSeconds / 60)분 집중")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                .buttonStyle(.plain)
+                
+                // 스케줄 정보 (상세 보기/타이머 시작)
+                Button {
+                    if !schedule.isCompleted && !focusManager.isAllInModeActive {
+                        focusManager.startFocus(on: schedule)
+                        showingTimer = true
                     }
-                    Spacer()
-                    if schedule.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                    } else if schedule.syncStatus == .pending {
-                        Image(systemName: "cloud.badge.plus")
-                            .foregroundColor(.orange)
-                            .font(.caption)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(schedule.name)
+                                .font(.headline)
+                                .foregroundColor(schedule.isCompleted ? .secondary : .primary)
+                            Text("\(schedule.durationSeconds / 60)분 집중")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if !schedule.isCompleted && schedule.syncStatus == .pending {
+                            Image(systemName: "cloud.badge.plus")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .disabled(focusManager.isAllInModeActive && !schedule.isCompleted)
             .contextMenu {
                 if !schedule.isCompleted {
                     Button {
@@ -151,9 +161,18 @@ struct ContentView: View {
 
     private var allInModeBanner: some View {
         HStack {
-            Image(systemName: "flame.fill")
-            Text("올인 모드 진행 중")
-                .fontWeight(.bold)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "flame.fill")
+                    Text("올인 모드 진행 중")
+                        .fontWeight(.bold)
+                }
+                if !homeViewModel.todayProgressText.isEmpty {
+                    Text(homeViewModel.todayProgressText)
+                        .font(.caption)
+                        .opacity(0.9)
+                }
+            }
             Spacer()
             Button("중단") {
                 focusManager.stopAllInMode()

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -59,6 +59,13 @@ struct ContentView: View {
             } message: {
                 Text("오늘 예정된 미완료 스케줄이 없습니다.")
             }
+            .alert("올인 모드 완료!", isPresented: $focusManager.showAllInCompletePopup) {
+                Button("축하합니다!") {
+                    focusManager.showAllInCompletePopup = false
+                }
+            } message: {
+                Text("오늘의 모든 스케줄을 완료하셨습니다.\n정말 고생 많으셨어요! 🎉")
+            }
             .alert("스케줄 삭제", isPresented: Binding(
                 get: { scheduleToDelete != nil },
                 set: { if !$0 { scheduleToDelete = nil } }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -40,6 +40,21 @@ struct ContentView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     allInModeToggle
                 }
+                
+                ToolbarItem(placement: .principal) {
+                    if homeViewModel.currentStreak > 0 {
+                        HStack(spacing: 4) {
+                            Text("🔥")
+                            Text("\(homeViewModel.currentStreak)일 연속")
+                                .fontWeight(.bold)
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Color.orange.opacity(0.1))
+                        .cornerRadius(12)
+                    }
+                }
+                
                 ToolbarItem(placement: .primaryAction) {
                     Button(action: { showingAddSheet = true }) {
                         Image(systemName: "plus")

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @StateObject private var repository = ScheduleRepository.shared
     @StateObject private var homeViewModel = HomeViewModel()
     @StateObject private var focusManager = FocusManager.shared
+    @StateObject private var screentimeManager = ScreentimeManager.shared
     @State private var showingAddSheet = false
     @State private var editingSchedule: Schedule?
     @State private var scheduleToDelete: Schedule?
@@ -102,6 +103,9 @@ struct ContentView: View {
                 }
             } message: {
                 Text("이 스케줄을 정말 삭제하시겠습니까?")
+            }
+            .fullScreenCover(isPresented: .constant(screentimeManager.authorizationStatus == .denied)) {
+                PermissionRequestView()
             }
         }
     }

--- a/ios-app/Unwind/Unwind/ContentView.swift
+++ b/ios-app/Unwind/Unwind/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State private var scheduleToDelete: Schedule?
     @State private var showingTimer = false
     @State private var showingAllInAlert = false
+    @State private var showingAllInAbandonAlert = false
     
     var body: some View {
         NavigationStack {
@@ -65,6 +66,14 @@ struct ContentView: View {
                 }
             } message: {
                 Text("오늘의 모든 스케줄을 완료하셨습니다.\n정말 고생 많으셨어요! 🎉")
+            }
+            .alert("올인 모드 중단", isPresented: $showingAllInAbandonAlert) {
+                Button("계속하기", role: .cancel) { }
+                Button("포기하기", role: .destructive) {
+                    focusManager.abandonAllInMode()
+                }
+            } message: {
+                Text("지금 중단하면 오늘은 실패로 기록됩니다.\n정말 포기하시겠습니까?")
             }
             .alert("스케줄 삭제", isPresented: Binding(
                 get: { scheduleToDelete != nil },
@@ -182,7 +191,7 @@ struct ContentView: View {
             }
             Spacer()
             Button("중단") {
-                focusManager.stopAllInMode()
+                showingAllInAbandonAlert = true
             }
             .buttonStyle(.bordered)
             .tint(.white)
@@ -195,7 +204,7 @@ struct ContentView: View {
     private var allInModeToggle: some View {
         Button {
             if focusManager.isAllInModeActive {
-                focusManager.stopAllInMode()
+                showingAllInAbandonAlert = true
             } else {
                 if homeViewModel.hasIncompleteSchedulesToday {
                     focusManager.startAllInMode()

--- a/ios-app/Unwind/Unwind/Models/DailyRecord.swift
+++ b/ios-app/Unwind/Unwind/Models/DailyRecord.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// 일별 기록 상태를 정의합니다.
+enum DailyStatus: String, Codable {
+    /// 성공 (모든 스케줄 완료)
+    case success
+    /// 실패 (올인 모드 중도 포기 등)
+    case failure
+    /// 경고 (일부 미완료)
+    case warning
+    /// 계획 없음
+    case noPlan = "noplan"
+}
+
+/// 날짜별 집중 기록을 나타내는 모델입니다.
+struct DailyRecord: Codable {
+    /// 기록 날짜 (YYYY-MM-DD 형식의 문자열을 Key로 사용하기 위해)
+    let date: String
+    /// 오늘의 상태
+    var status: DailyStatus
+    /// 전체 스케줄 수
+    var totalSchedules: Int
+    /// 완료된 스케줄 수
+    var completedSchedules: Int
+    /// 올인 모드 사용 여부
+    var allInModeUsed: Bool
+    /// 서버 동기화 상태
+    var syncStatus: SyncStatus
+    
+    init(date: String, 
+         status: DailyStatus = .noPlan, 
+         totalSchedules: Int = 0, 
+         completedSchedules: Int = 0, 
+         allInModeUsed: Bool = false, 
+         syncStatus: SyncStatus = .pending) {
+        self.date = date
+        self.status = status
+        self.totalSchedules = totalSchedules
+        self.completedSchedules = completedSchedules
+        self.allInModeUsed = allInModeUsed
+        self.syncStatus = syncStatus
+    }
+}
+

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -84,6 +84,15 @@ class FocusManager: ObservableObject {
         stopAllInMonitoring()
     }
     
+    /// 올인 모드를 중단(포기)했을 때 호출됩니다.
+    func abandonAllInMode() {
+        // 1. 상태 업데이트 (오늘의 전체 기록을 실패로 마킹)
+        ScheduleRepository.shared.updateDailyStatus(for: Date(), status: .failure)
+        
+        // 2. 올인 모드 종료 (차단 해제 등)
+        stopAllInMode()
+    }
+    
     private func tick() {
         if timeRemaining > 0 {
             timeRemaining -= 1

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -14,6 +14,7 @@ class FocusManager: ObservableObject {
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")
+            sharedDefaults?.set(isAllInModeActive, forKey: "isAllInModeActive")
         }
     }
     

--- a/ios-app/Unwind/Unwind/Services/FocusManager.swift
+++ b/ios-app/Unwind/Unwind/Services/FocusManager.swift
@@ -11,6 +11,7 @@ class FocusManager: ObservableObject {
     @Published var timeRemaining: Int = 0
     @Published var isFocusing: Bool = false
     @Published var showSuccessScreen: Bool = false
+    @Published var showAllInCompletePopup: Bool = false
     @Published var isAllInModeActive: Bool = false {
         didSet {
             UserDefaults.standard.set(isAllInModeActive, forKey: "isAllInModeActive")

--- a/ios-app/Unwind/Unwind/Services/ScreentimeManager.swift
+++ b/ios-app/Unwind/Unwind/Services/ScreentimeManager.swift
@@ -13,12 +13,22 @@ class ScreentimeManager: ObservableObject {
         }
     }
     
+    @Published var authorizationStatus: AuthorizationStatus = .notDetermined
+    
     private init() {
         loadSelection()
+        updateAuthorizationStatus()
     }
     
     func requestAuthorization() async throws {
         try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
+        updateAuthorizationStatus()
+    }
+    
+    func updateAuthorizationStatus() {
+        DispatchQueue.main.async {
+            self.authorizationStatus = AuthorizationCenter.shared.authorizationStatus
+        }
     }
     
     private func saveSelection() {

--- a/ios-app/Unwind/Unwind/UnwindApp.swift
+++ b/ios-app/Unwind/Unwind/UnwindApp.swift
@@ -22,6 +22,7 @@ struct UnwindApp: App {
                     if newPhase == .active {
                         // 앱이 포그라운드로 올라올 때마다 권한 상태를 체크합니다.
                         penaltyManager.checkAuthorizationStatus()
+                        ScreentimeManager.shared.updateAuthorizationStatus()
                     }
                 }
         }

--- a/ios-app/Unwind/Unwind/Utils/StreakCalculator.swift
+++ b/ios-app/Unwind/Unwind/Utils/StreakCalculator.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// 사용자의 연속 성공(Streak)을 계산하는 유틸리티 클래스입니다.
+struct StreakCalculator {
+    /// 현재까지의 연속 성공 일수를 계산합니다.
+    /// - Parameter dailyRecords: 일별 기록 딕셔너리 (Key: "yyyy-MM-dd")
+    /// - Returns: 연속 성공 일수
+    static func calculateCurrentStreak(from dailyRecords: [String: DailyRecord]) -> Int {
+        let calendar = Calendar.current
+        var streak = 0
+        var checkDate = Date()
+        
+        // 오늘 이미 성공했는지 확인
+        let todayString = formatDate(checkDate)
+        if dailyRecords[todayString]?.status == .success {
+            streak += 1
+        } else if dailyRecords[todayString]?.status == .failure {
+            // 오늘 실패했다면 스트릭은 0
+            return 0
+        }
+        // 오늘이 아직 success도 failure도 아니라면(pending) 어제부터 역순으로 계산 시작
+        
+        // 어제부터 역순으로 탐색
+        while let yesterday = calendar.date(byAdding: .day, value: -1, to: checkDate) {
+            let dateString = formatDate(yesterday)
+            
+            if let record = dailyRecords[dateString] {
+                if record.status == .success {
+                    streak += 1
+                } else if record.status == .noPlan {
+                    // 계획 없는 날은 스트릭 유지 (건너뜀)
+                    // 단, 이미 스트릭이 시작된 경우에만 의미가 있음
+                    checkDate = yesterday
+                    continue
+                } else {
+                    // 실패(failure)나 경고(warning)가 있으면 스트릭 중단
+                    break
+                }
+            } else {
+                // 기록이 없는 날은 계획 없는 날과 동일하게 취급하여 스트릭 유지
+                checkDate = yesterday
+                continue
+            }
+            
+            checkDate = yesterday
+            
+            // 무한 루프 방지 및 합리적인 최대치 설정 (예: 10년)
+            if streak > 3650 { break }
+        }
+        
+        return streak
+    }
+    
+    private static func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}
+

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -12,6 +12,7 @@ class HomeViewModel: ObservableObject {
         }
     }
     @Published var todayStatus: DailyStatus = .noPlan
+    @Published var currentStreak: Int = 0
     
     // 오늘 남은 스케줄이 있는지 확인
     var hasIncompleteSchedulesToday: Bool {
@@ -79,6 +80,14 @@ class HomeViewModel: ObservableObject {
                 return records[dateString]?.status ?? .noPlan
             }
             .assign(to: \.todayStatus, on: self)
+            .store(in: &cancellables)
+            
+        // 스트릭 계산 바인딩
+        repository.$dailyRecords
+            .map { records in
+                return StreakCalculator.calculateCurrentStreak(from: records)
+            }
+            .assign(to: \.currentStreak, on: self)
             .store(in: &cancellables)
     }
     

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -89,5 +89,23 @@ class HomeViewModel: ObservableObject {
         }
         updatedSchedule.updatedAt = Date()
         repository.updateSchedule(updatedSchedule)
+        
+        // 전체 완료 여부 체크 (올인 모드 해제 로직)
+        checkAllInCompletion()
+    }
+    
+    private func checkAllInCompletion() {
+        guard FocusManager.shared.isAllInModeActive else { return }
+        
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let todaysSchedules = repository.schedules.filter { 
+            calendar.isDate($0.createdAt, inSameDayAs: today) && $0.deletedAt == nil
+        }
+        
+        if !todaysSchedules.isEmpty && todaysSchedules.allSatisfy({ $0.isCompleted }) {
+            FocusManager.shared.stopAllInMode()
+            FocusManager.shared.showAllInCompletePopup = true
+        }
     }
 }

--- a/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
+++ b/ios-app/Unwind/Unwind/ViewModels/HomeViewModel.swift
@@ -6,7 +6,11 @@ class HomeViewModel: ObservableObject {
     @Published var selectedDate: Date = Date()
     @Published var filteredSchedules: [Schedule] = []
     @Published var dateChips: [Date] = []
-    @Published var todayProgressText: String = ""
+    @Published var todayProgressText: String = "" {
+        didSet {
+            UserDefaults(suiteName: "group.com.unwind.data")?.set(todayProgressText, forKey: "allInModeProgress")
+        }
+    }
     
     // 오늘 남은 스케줄이 있는지 확인
     var hasIncompleteSchedulesToday: Bool {

--- a/ios-app/Unwind/Unwind/Views/PermissionRequestView.swift
+++ b/ios-app/Unwind/Unwind/Views/PermissionRequestView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import FamilyControls
+
+struct PermissionRequestView: View {
+    @StateObject private var screentimeManager = ScreentimeManager.shared
+    
+    var body: some View {
+        VStack(spacing: 30) {
+            Spacer()
+            
+            Image(systemName: "lock.shield.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.orange)
+            
+            VStack(spacing: 12) {
+                Text("권한이 필요합니다")
+                    .font(.title)
+                    .fontWeight(.bold)
+                
+                Text("앱 차단 기능을 사용하기 위해서는\n스크린 타임 권한 허용이 필수적입니다.\n설정에서 권한을 허용해주세요.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .lineSpacing(4)
+            }
+            .padding(.horizontal, 40)
+            
+            Spacer()
+            
+            VStack(spacing: 16) {
+                Button(action: {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }) {
+                    Text("설정으로 이동")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.orange)
+                        .cornerRadius(12)
+                }
+                
+                Button(action: {
+                    Task {
+                        try? await screentimeManager.requestAuthorization()
+                    }
+                }) {
+                    Text("다시 시도")
+                        .font(.subheadline)
+                        .foregroundColor(.orange)
+                }
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 50)
+        }
+        .background(Color(.systemBackground))
+    }
+}
+
+#Preview {
+    PermissionRequestView()
+}
+


### PR DESCRIPTION
## 개요
앱의 핵심 기능인 스크린 타임(FamilyControls) 권한이 거부되었을 때, 사용자를 안내하고 설정을 유도하는 UI를 구현했습니다.

## 주요 변경 사항
1. **권한 상태 관리 기능 추가 (`ScreentimeManager.swift`)**
   - `AuthorizationCenter.shared.authorizationStatus`를 실시간으로 감시할 수 있도록 `@Published var authorizationStatus` 프로퍼티를 추가했습니다.
   - 앱이 포그라운드로 올라올 때마다 상태를 업데이트하는 `updateAuthorizationStatus()` 메서드를 구현했습니다.

2. **권한 요청 안내 뷰 구현 (`PermissionRequestView.swift`)**
   - 권한 거부 시 표시될 전용 안내 화면을 제작했습니다.
   - 앱 설정 화면으로 즉시 이동할 수 있는 버튼(`UIApplication.openSettingsURLString`)을 제공합니다.

3. **메인 화면 연동 (`ContentView.swift`)**
   - `ScreentimeManager`의 권한 상태가 `.denied`인 경우, `PermissionRequestView`를 `fullScreenCover`로 띄워 메인 기능 사용을 제한하고 권한 허용을 유도합니다.

4. **앱 생명주기 연동 (`UnwindApp.swift`)**
   - `scenePhase`가 `.active`로 변경될 때마다 권한 상태를 최신화하여, 설정에서 권한을 변경하고 돌아온 경우 즉시 UI에 반영되도록 했습니다.

## 관련 이슈
- Closes #114
